### PR TITLE
feat: added support for multiple security groups.

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,54 @@ auth:
 ```
 
 Note that when using the `groupName` parameter, the plugin will require at least one security group to exist on the user in order to successfully authenticate.
+
+# Examples
+
+## Restricting a specific scope
+Groups(s) defined in the `groupName` secion of the activedirectory configuration become available to the `packages` block of config.yaml. This can be used to restrict certain actions. Below, the scope `@internal-scope` is only accessable to users belowing to `npmUsers`:
+
+```
+auth:
+  activedirectory:
+    url: "ldap://10.0.100.1"
+    baseDN: 'dc=sample,dc=local'
+    domainSuffix: 'sample.local'
+    groupName: 'npmUsers' 
+
+packages:
+  '@internal-scope/*':
+    access: npmUsers
+    publish: npmUsers
+    unpublish: npmUsers
+
+  '**':
+    access: $all
+    proxy: npmjs
+```
+
+## Using multiple groups for access control
+By providing multple groups in the `groupName` section, we can restrict actions to individual classes of users. In this example we:
+- allow anyone to view and install packages within `@internal-scope` 
+- have restricted publishing to users who belong to `npmWriters` or `npmAdmins`
+- only allow `npmAdmins` to unpublish packages
+
+```
+auth:
+  activedirectory:
+    url: "ldap://10.0.100.1"
+    baseDN: 'dc=sample,dc=local'
+    domainSuffix: 'sample.local'
+    groupName: 
+      - npmWriters
+      - npmAdmins
+
+packages:
+  '@internal-scope/*':
+    access: $all
+    publish: npmUsers npmAdmins
+    unpublish: npmAdmins
+
+  '**':
+    access: $all
+    proxy: npmjs
+```

--- a/README.md
+++ b/README.md
@@ -20,3 +20,18 @@ auth:
     domainSuffix: 'sample.local'
     groupName: 'npmWriters' # optional
 ```
+
+Alternatively, if your config.yaml uses multiple security groups, you can provide a yaml sequence:
+
+```yaml
+auth:
+  activedirectory:
+    url: "ldap://10.0.100.1"
+    baseDN: 'dc=sample,dc=local'
+    domainSuffix: 'sample.local'
+    groupName:
+      - 'npmWriters'
+      - 'npmAdministrators'
+```
+
+Note that when using the `groupName` parameter, the plugin will require at least one security group to exist on the user in order to successfully authenticate.

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,152 +1,293 @@
 {
   "name": "verdaccio-activedirectory",
-  "version": "1.0.0",
+  "version": "1.1.0",
+  "lockfileVersion": 1,
+  "requires": true,
   "dependencies": {
     "activedirectory": {
       "version": "0.7.2",
-      "from": "activedirectory@>=0.7.2 <0.8.0"
+      "resolved": "https://registry.npmjs.org/activedirectory/-/activedirectory-0.7.2.tgz",
+      "integrity": "sha1-GShtEMaySpjMkG3GOCVhkWhvqR8=",
+      "requires": {
+        "async": ">= 0.1.22",
+        "bunyan": ">= 1.3.5",
+        "ldapjs": ">= 0.7.1",
+        "underscore": ">= 1.4.3"
+      }
     },
     "asn1": {
       "version": "0.2.3",
-      "from": "asn1@0.2.3"
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
     },
     "assert-plus": {
-      "version": "0.1.5",
-      "from": "assert-plus@0.1.5"
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
     },
     "async": {
-      "version": "1.5.2",
-      "from": "async@>=0.1.22"
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.1.0.tgz",
+      "integrity": "sha512-4vx/aaY6j/j3Lw3fbCHNWP0pPaTCew3F6F3hYyl/tHs/ndmV1q7NW9T5yuJ2XAGwdQrP+6Wu20x06U4APo/iQQ=="
     },
     "backoff": {
-      "version": "2.4.1",
-      "from": "backoff@2.4.1"
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/backoff/-/backoff-2.5.0.tgz",
+      "integrity": "sha1-9hbtqdPktmuMp/ynn2lXIsX44m8=",
+      "requires": {
+        "precond": "0.2"
+      }
     },
     "balanced-match": {
-      "version": "0.4.1",
-      "from": "balanced-match@>=0.4.1 <0.5.0"
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "optional": true
     },
     "brace-expansion": {
-      "version": "1.1.5",
-      "from": "brace-expansion@>=1.0.0 <2.0.0"
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "optional": true,
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
     },
     "bunyan": {
-      "version": "1.8.1",
-      "from": "bunyan@>=1.3.5"
+      "version": "1.8.12",
+      "resolved": "https://registry.npmjs.org/bunyan/-/bunyan-1.8.12.tgz",
+      "integrity": "sha1-8VDw9nSKvdcq6uhPBEA74u8RN5c=",
+      "requires": {
+        "dtrace-provider": "~0.8",
+        "moment": "^2.10.6",
+        "mv": "~2",
+        "safe-json-stringify": "~1"
+      }
     },
     "concat-map": {
       "version": "0.0.1",
-      "from": "concat-map@0.0.1"
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "optional": true
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "dashdash": {
-      "version": "1.10.1",
-      "from": "dashdash@1.10.1"
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "requires": {
+        "assert-plus": "^1.0.0"
+      }
     },
     "dtrace-provider": {
-      "version": "0.6.0",
-      "from": "dtrace-provider@>=0.6.0 <0.7.0"
+      "version": "0.8.7",
+      "resolved": "https://registry.npmjs.org/dtrace-provider/-/dtrace-provider-0.8.7.tgz",
+      "integrity": "sha1-3JObTT4GIM/gwc2APQ0tftBP/QQ=",
+      "optional": true,
+      "requires": {
+        "nan": "^2.10.0"
+      }
     },
     "extsprintf": {
       "version": "1.2.0",
-      "from": "extsprintf@1.2.0"
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.2.0.tgz",
+      "integrity": "sha1-WtlGwi9bMrp/jNdCZxHG6KP8JSk="
     },
     "glob": {
       "version": "6.0.4",
-      "from": "glob@>=6.0.1 <7.0.0"
+      "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
+      "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
+      "optional": true,
+      "requires": {
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "2 || 3",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
     },
     "inflight": {
-      "version": "1.0.5",
-      "from": "inflight@>=1.0.4 <2.0.0"
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "optional": true,
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
     },
     "inherits": {
-      "version": "2.0.1",
-      "from": "inherits@>=2.0.0 <3.0.0"
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "optional": true
     },
     "ldap-filter": {
       "version": "0.2.2",
-      "from": "ldap-filter@0.2.2"
-    },
-    "ldapjs": {
-      "version": "1.0.0",
-      "from": "ldapjs@>=0.7.1",
+      "resolved": "https://registry.npmjs.org/ldap-filter/-/ldap-filter-0.2.2.tgz",
+      "integrity": "sha1-8rhCvguG2jNSeYUFsx68rlkNd9A=",
+      "requires": {
+        "assert-plus": "0.1.5"
+      },
       "dependencies": {
-        "bunyan": {
-          "version": "1.5.1",
-          "from": "bunyan@1.5.1"
-        },
-        "once": {
-          "version": "1.3.2",
-          "from": "once@1.3.2"
+        "assert-plus": {
+          "version": "0.1.5",
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz",
+          "integrity": "sha1-7nQAlBMALYTOxyGcasgRgS5yMWA="
         }
       }
     },
+    "ldapjs": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/ldapjs/-/ldapjs-1.0.2.tgz",
+      "integrity": "sha1-VE/3Ayt7g8aPBwEyjZKXqmlDQPk=",
+      "requires": {
+        "asn1": "0.2.3",
+        "assert-plus": "^1.0.0",
+        "backoff": "^2.5.0",
+        "bunyan": "^1.8.3",
+        "dashdash": "^1.14.0",
+        "dtrace-provider": "~0.8",
+        "ldap-filter": "0.2.2",
+        "once": "^1.4.0",
+        "vasync": "^1.6.4",
+        "verror": "^1.8.1"
+      }
+    },
     "lodash": {
-      "version": "4.13.1",
-      "from": "lodash@>=4.13.1 <5.0.0"
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
     "minimatch": {
-      "version": "3.0.2",
-      "from": "minimatch@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0"
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "optional": true,
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
     },
     "minimist": {
       "version": "0.0.8",
-      "from": "minimist@0.0.8"
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "optional": true
     },
     "mkdirp": {
       "version": "0.5.1",
-      "from": "mkdirp@>=0.5.1 <0.6.0"
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "optional": true,
+      "requires": {
+        "minimist": "0.0.8"
+      }
     },
     "moment": {
-      "version": "2.13.0",
-      "from": "moment@>=2.10.6 <3.0.0"
+      "version": "2.24.0",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
+      "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==",
+      "optional": true
     },
     "mv": {
       "version": "2.1.1",
-      "from": "mv@>=2.0.0 <3.0.0"
+      "resolved": "https://registry.npmjs.org/mv/-/mv-2.1.1.tgz",
+      "integrity": "sha1-rmzg1vbV4KT32JN5jQPB6pVZtqI=",
+      "optional": true,
+      "requires": {
+        "mkdirp": "~0.5.1",
+        "ncp": "~2.0.0",
+        "rimraf": "~2.4.0"
+      }
     },
     "nan": {
-      "version": "2.3.5",
-      "from": "nan@>=2.0.8 <3.0.0"
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+      "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
+      "optional": true
     },
     "ncp": {
       "version": "2.0.0",
-      "from": "ncp@>=2.0.0 <2.1.0"
+      "resolved": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz",
+      "integrity": "sha1-GVoh1sRuNh0vsSgbo4uR6d9727M=",
+      "optional": true
     },
     "once": {
-      "version": "1.3.3",
-      "from": "once@>=1.3.0 <2.0.0"
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "requires": {
+        "wrappy": "1"
+      }
     },
     "path-is-absolute": {
-      "version": "1.0.0",
-      "from": "path-is-absolute@>=1.0.0 <2.0.0"
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "optional": true
     },
     "precond": {
       "version": "0.2.3",
-      "from": "precond@>=0.2.0 <0.3.0"
+      "resolved": "https://registry.npmjs.org/precond/-/precond-0.2.3.tgz",
+      "integrity": "sha1-qpWRvKokkj8eD0hJ0kD0fvwQdaw="
     },
     "rimraf": {
       "version": "2.4.5",
-      "from": "rimraf@>=2.4.0 <2.5.0"
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.5.tgz",
+      "integrity": "sha1-7nEM5dk6j9uFb7Xqj/Di11k0sto=",
+      "optional": true,
+      "requires": {
+        "glob": "^6.0.1"
+      }
     },
     "safe-json-stringify": {
-      "version": "1.0.3",
-      "from": "safe-json-stringify@>=1.0.0 <2.0.0"
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/safe-json-stringify/-/safe-json-stringify-1.2.0.tgz",
+      "integrity": "sha512-gH8eh2nZudPQO6TytOvbxnuhYBOvDBBLW52tz5q6X58lJcd/tkmqFR+5Z9adS8aJtURSXWThWy/xJtJwixErvg==",
+      "optional": true
     },
     "underscore": {
-      "version": "1.8.3",
-      "from": "underscore@>=1.4.3"
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.1.tgz",
+      "integrity": "sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg=="
     },
     "vasync": {
-      "version": "1.6.3",
-      "from": "vasync@1.6.3"
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/vasync/-/vasync-1.6.4.tgz",
+      "integrity": "sha1-3+k2Fq0OeugBszKp2Iv8XNyOHR8=",
+      "requires": {
+        "verror": "1.6.0"
+      },
+      "dependencies": {
+        "verror": {
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/verror/-/verror-1.6.0.tgz",
+          "integrity": "sha1-fROyex+swuLakEBetepuW90lLqU=",
+          "requires": {
+            "extsprintf": "1.2.0"
+          }
+        }
+      }
     },
     "verror": {
-      "version": "1.6.0",
-      "from": "verror@1.6.0"
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "requires": {
+        "assert-plus": "^1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "^1.2.0"
+      }
     },
     "wrappy": {
       "version": "1.0.2",
-      "from": "wrappy@>=1.0.0 <2.0.0"
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     }
   }
 }


### PR DESCRIPTION
## Overview
Currently, there is an optional parameter `groupName` which is used to ensure that a user belongs to a specific active directory security group. Additionally, when successfully authenticated, the security group is added to the Verdaccio `groups` array for the purpose of role based authentication.

This plugin allows a yaml sequence to be passed in to validate multiple security groups. This allows for more granularity in the authentication process so that the plugin will support multiple levels of access.

## Examples
### Scoped packages
This will allow users in npmWriters to both publish and unpublish to `@internal-scope`. This is the existing behavior.
```
auth:
  activedirectory:
    url: "ldap://10.0.100.1"
    baseDN: 'dc=sample,dc=local'
    domainSuffix: 'sample.local'
    groupName: 'npmWriters' 

packages:
  '@internal-scope/*':
    access: $all
    publish: npmWriters
    unpublish: npmWriters

  '**':
    access: $all
    proxy: npmjs
```

### Restrictions to unpublish
This will allow users in npmWriters to only publish. Users belonging to npmAdmins may publish and unpublish packages.
```
auth:
  activedirectory:
    url: "ldap://10.0.100.1"
    baseDN: 'dc=sample,dc=local'
    domainSuffix: 'sample.local'
    groupName: 
      - npmWriters
      - npmAdmins

packages:
  '@internal-scope/*':
    access: $all
    publish: npmWriters npmAdmins
    unpublish: npmAdmins

  '**':
    access: $all
    proxy: npmjs
```